### PR TITLE
Slice 5: Restyle Hero, NavBar & Footer (modern minimal, both themes)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,13 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+
     <meta itemProp="name" content="Adrian Eyre" />
     <meta itemProp="description" content="Portfolio site of Adrian Eyre" />
     <meta itemProp="image" content="http://adrianeyre.co.uk/images/meta/banner.png" />

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -5,9 +5,19 @@ const thisYear = new Date().getFullYear();
 
 const Footer = () => (
   <footer className="footer-panel">
-    <span>&#169;{thisYear} {author} |</span>
-    <span> Version {version} |</span>
-    <span> <a href="https://github.com/adrianeyre/portfolio" rel="noopener noreferrer" target="_blank">Website Design</a></span>
+    <div className="footer-inner">
+      <span className="footer-credit">&#169; {thisYear} {author}</span>
+      <span className="footer-sep" aria-hidden="true">·</span>
+      <span className="footer-version">Version {version}</span>
+      <span className="footer-sep" aria-hidden="true">·</span>
+      <a
+        href="https://github.com/adrianeyre/portfolio"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Website Design
+      </a>
+    </div>
   </footer>
 );
 

--- a/src/layout/Hero.tsx
+++ b/src/layout/Hero.tsx
@@ -1,9 +1,11 @@
+import Reveal from '../components/Reveal';
+
 const scrollTo = (id: string) =>
   document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
 const Hero = () => (
   <header className="hero">
-    <div className="hero-body">
+    <Reveal className="hero-body">
       <span className="eyebrow">Lead Software Developer</span>
       <h1>Adrian Eyre</h1>
       <p>Building modern applications using AI and cloud-native tooling.</p>
@@ -11,8 +13,8 @@ const Hero = () => (
         <button onClick={() => scrollTo('projects')}>View Projects</button>
         <button className="secondary" onClick={() => scrollTo('about')}>About Me</button>
       </div>
-    </div>
-    <div className="hero-side">
+    </Reveal>
+    <Reveal className="hero-side" delay={0.12}>
       <div className="hero-card">
         <span>Experience</span>
         <strong>15+ years</strong>
@@ -25,7 +27,7 @@ const Hero = () => (
         <span>Focus</span>
         <strong>Leadership · Architecture · Team Management</strong>
       </div>
-    </div>
+    </Reveal>
   </header>
 );
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,12 @@
 :root {
-  font-family: 'Saira Extra Condensed', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  /* Type system — modern-minimal: Inter for UI/body, Space Grotesk for display. */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-display: 'Space Grotesk', var(--font-sans);
+
+  font-family: var(--font-sans);
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   background: var(--bg);
   color: var(--text);
 }
@@ -46,6 +53,7 @@
   /* Shadows */
   --shadow-action: 0 10px 20px rgba(25, 47, 78, 0.18);
   --shadow-thumb: 0 8px 16px rgba(91, 192, 190, 0.3);
+  --shadow-nav: 0 8px 24px rgba(0, 0, 0, 0.4);
   --thumb-border: rgba(91, 192, 190, 0.2);
 }
 
@@ -84,6 +92,7 @@
   /* Shadows */
   --shadow-action: 0 10px 20px rgba(25, 47, 78, 0.12);
   --shadow-thumb: 0 8px 16px rgba(22, 138, 136, 0.22);
+  --shadow-nav: 0 8px 24px rgba(12, 22, 38, 0.14);
   --thumb-border: rgba(22, 138, 136, 0.28);
 }
 
@@ -136,29 +145,35 @@ a {
 }
 
 .hero-body h1 {
-  margin: 18px 0 16px;
+  margin: 20px 0 18px;
+  font-family: var(--font-display);
   font-size: clamp(3rem, 5vw, 5rem);
-  line-height: 0.95;
+  font-weight: 700;
+  line-height: 0.98;
+  letter-spacing: -0.03em;
 }
 
 .hero-body p {
   margin: 0;
   color: var(--text-muted);
-  font-size: 1.05rem;
-  line-height: 1.75;
+  font-size: 1.15rem;
+  line-height: 1.7;
+  max-width: 48ch;
 }
 
 .eyebrow {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 16px;
+  padding: 8px 16px;
   border-radius: 999px;
   background: var(--accent-soft);
+  border: 1px solid var(--border-subtle);
   color: var(--accent-text);
-  font-size: 0.88rem;
+  font-size: 0.78rem;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.16em;
 }
 
 .hero-actions {
@@ -169,23 +184,40 @@ a {
 }
 
 .hero-actions button {
-  border: none;
-  padding: 14px 24px;
+  border: 1px solid transparent;
+  padding: 14px 26px;
   border-radius: 999px;
   background: var(--gradient);
   color: var(--dark);
-  font-weight: 700;
-  transition: transform 0.2s ease, opacity 0.2s ease;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: var(--shadow-action);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease,
+    background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .hero-actions button.secondary {
   background: transparent;
-  border: 1px solid var(--border-strong);
+  border-color: var(--border-strong);
   color: var(--text);
+  box-shadow: none;
 }
 
 .hero-actions button:hover {
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-thumb);
+}
+
+.hero-actions button.secondary:hover {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent-text);
+  box-shadow: none;
+}
+
+.hero-actions button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .hero-side {
@@ -197,18 +229,29 @@ a {
   background: var(--card-bg);
   border: 1px solid var(--border);
   padding: 22px;
-  border-radius: 24px;
+  border-radius: 20px;
   display: grid;
-  gap: 10px;
+  gap: 8px;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-action);
 }
 
 .hero-card span {
   color: var(--text-muted);
-  font-size: 0.92rem;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
 }
 
 .hero-card strong {
   font-size: 1.14rem;
+  font-weight: 600;
 }
 
 .slick-arrow {
@@ -231,14 +274,20 @@ a {
   z-index: 20;
   backdrop-filter: blur(18px);
   background: var(--nav-bg);
-  border-bottom: 1px solid var(--border-subtle);
-  border-radius: 24px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
   width: 100%;
   margin: 16px 0 0;
+  transition: border-radius 0.25s ease, box-shadow 0.25s ease, margin 0.25s ease;
 }
 
 .nav-bar.scrolled {
   border-radius: 0;
+  border-left-color: transparent;
+  border-right-color: transparent;
+  border-top-color: transparent;
+  margin-top: 0;
+  box-shadow: var(--shadow-nav);
 }
 
 .nav-inner {
@@ -273,9 +322,10 @@ a {
   border: none;
   background: transparent;
   color: var(--text-muted);
-  padding: 12px 16px;
-  border-radius: 12px;
-  font-size: 16px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 500;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
@@ -288,6 +338,11 @@ a {
   background: var(--accent-soft);
   color: var(--accent-text);
   font-weight: 600;
+}
+
+.nav-links button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .nav-interests {
@@ -357,15 +412,20 @@ a {
 }
 
 .section-tag {
+  font-family: var(--font-display);
   font-size: clamp(2rem, 3vw, 2.8rem);
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.16em;
   color: var(--accent);
 }
 
 .section h2 {
   margin: 0;
+  font-family: var(--font-display);
   font-size: clamp(1.8rem, 2.5vw, 2.2rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .about-grid,
@@ -653,20 +713,45 @@ a {
 .footer-panel {
   position: sticky;
   bottom: 0;
-  padding: 10px;
-  background: var(--card-bg);
-  border: 1px solid var(--border);
-  font-size: 1.2rem;
-  text-align: center;
+  padding: 18px 24px;
+  background: var(--nav-bg);
+  backdrop-filter: blur(18px);
+  border-top: 1px solid var(--border-subtle);
 }
 
-.footer-panel h3 {
-  margin: 0 0 5px;
-}
-
-.footer-panel p {
-  margin: 0;
+.footer-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
   color: var(--text-muted);
+  font-size: 0.92rem;
+  letter-spacing: 0.01em;
+}
+
+.footer-sep {
+  color: var(--border-strong);
+}
+
+.footer-panel a {
+  color: var(--accent-text);
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.footer-panel a:hover {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.footer-panel a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 .social-icon {
@@ -734,10 +819,16 @@ a {
     width: 100%;
   }
 
+  .nav-bar {
+    border-radius: 16px;
+  }
+
   .nav-inner {
-    padding: 0;
+    padding: 12px 16px;
     height: auto;
-  };
+    flex-wrap: wrap;
+    justify-content: center;
+  }
 
   .nav-logo {
     display: none;
@@ -784,14 +875,6 @@ a {
     width: 100%;
   }
 
-  .nav-inner {
-    /* padding: 0; */
-  };
-
-  /* .nav-logo {
-    display: none;
-  } */
-
   .about-grid,
   .split-grid {
     grid-template-columns: 1fr;
@@ -799,5 +882,6 @@ a {
 
   .nav-links {
     width: 100%;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
Closes #26. Part of the visual redesign (#21). Stacked on top of #30 (Slice 4) — base it on `feature/scroll-spy-nav`; the diff resolves to `master` once Slice 4 merges.

## What changed

Restyles the persistent chrome — Hero, NavBar, Footer — to the modern-minimal direction (Linear/Vercel vibe) using the existing design tokens, in both light and dark themes, and lands the type-system font upgrade.

### Type system
- Add **Inter** (UI/body) and **Space Grotesk** (display) via Google Fonts, exposed as `--font-sans` / `--font-display` tokens.
- Display font + tightened tracking/weights applied to the hero headline and section headings.

### Hero
- Wrapped in `Reveal` for a staggered fade/translate entrance (honors reduced motion).
- Refined eyebrow, primary/secondary buttons (hover lift + shadow, `:focus-visible`), and stat cards (hover lift, uppercase labels).

### NavBar
- Floating pill that squares off and gains a per-theme shadow on scroll.
- Pill-shaped links with keyboard `:focus-visible` states; centered wrapping on small screens.

### Footer
- Cleaner single-row layout with separators; accent link with hover underline + `:focus-visible`; token-driven surface.

### Tokens
- Added per-theme `--shadow-nav` (tokens-only, no hard-coded component colors).

## Acceptance criteria
- [x] Hero, NavBar, Footer restyled to modern-minimal, both themes
- [x] New web font(s) applied for the type system
- [x] Cohesive/legible in light and dark
- [x] Responsive across existing breakpoints
- [x] Existing content and links preserved
- [x] `npm run build` succeeds (and 16 tests pass)

## Verification
- `npm run build` ✓
- `npm test` → 16 passed ✓
- No browser available in this environment, so visual cohesion was reviewed via the diff; recommend a manual cross-theme/responsive pass (covered by Slice 7, #28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)