### PR TITLE
Restyle content sections to modern-minimal with scroll reveals (#27)

### DIFF
--- a/src/sections/Codewars.tsx
+++ b/src/sections/Codewars.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Reveal from '../components/Reveal';
 import SectionHeader from '../components/SectionHeader';
 import ProjectActions from '../components/ProjectActions';
 import codewarsData from '../data/codewars.json';
@@ -13,7 +14,9 @@ const Codewars = () => {
 
   return (
     <section id="codewars" className="section panel">
-      <SectionHeader tag="Codewars" title="Authored Katas" />
+      <Reveal>
+        <SectionHeader tag="Codewars" title="Authored Katas" />
+      </Reveal>
       {showAll && (
         <button className="kata-expand-btn kata-expand-btn--up" onClick={() => setShowAll(false)} aria-label="Show less">
           ▲ show less
@@ -21,22 +24,23 @@ const Codewars = () => {
       )}
       <div className="grid project-grid">
         {visibleKatas.map((item, index) => (
-          <article
-            className={`project-card kata-card${expanded === index ? ' expanded' : ''}`}
-            key={index}
-            onClick={() => setExpanded(expanded === index ? null : index)}
-          >
-            <div className="project-body">
-              <div className="kata-content">
-                <h3>{item.title}</h3>
-                <div className="tag-list">
-                  {item.tags?.map((tag) => <span key={tag}>{tag}</span>)}
+          <Reveal key={index} delay={(index % 3) * 0.08}>
+            <article
+              className={`project-card kata-card${expanded === index ? ' expanded' : ''}`}
+              onClick={() => setExpanded(expanded === index ? null : index)}
+            >
+              <div className="project-body">
+                <div className="kata-content">
+                  <h3>{item.title}</h3>
+                  <div className="tag-list">
+                    {item.tags?.map((tag) => <span key={tag}>{tag}</span>)}
+                  </div>
+                  <p>{item.body}</p>
                 </div>
-                <p>{item.body}</p>
+                <ProjectActions links={item.links} />
               </div>
-              <ProjectActions links={item.links} />
-            </div>
-          </article>
+            </article>
+          </Reveal>
         ))}
       </div>
       {!showAll && (

--- a/src/sections/Education.tsx
+++ b/src/sections/Education.tsx
@@ -1,3 +1,4 @@
+import Reveal from '../components/Reveal';
 import SectionHeader from '../components/SectionHeader';
 import TitleImage from '../components/TitleImage';
 import educationData from '../data/education.json';
@@ -6,36 +7,44 @@ import experienceData from '../data/experience.json';
 const Education = () => (
   <section id="education" className="section panel split-grid">
     <div>
-      <SectionHeader tag="Education" title="Formal Learning" />
+      <Reveal>
+        <SectionHeader tag="Education" title="Formal Learning" />
+      </Reveal>
       {educationData.map((item, index) => (
-        <article className="timeline-card" key={index}>
-          <h3>
-            <TitleImage filename={item.image?.filename} link={item.image?.link} alt={item.title} />
-            {item.title}
-          </h3>
-          {item.subTitle && item.subTitle.map((subTitleItem) => <p key={subTitleItem}>{subTitleItem}</p>)}
-          {item.points?.length ? <ul>{item.points.map((point) => <li key={point}>{point}</li>)}</ul> : null}
-          {item.image?.link ? (
-            <a href={item.image.link} target="_blank" rel="noreferrer">View credential</a>
-          ) : null}
-        </article>
+        <Reveal key={index} delay={index * 0.08}>
+          <article className="timeline-card">
+            <h3>
+              <TitleImage filename={item.image?.filename} link={item.image?.link} alt={item.title} />
+              {item.title}
+            </h3>
+            {item.subTitle && item.subTitle.map((subTitleItem) => <p key={subTitleItem}>{subTitleItem}</p>)}
+            {item.points?.length ? <ul>{item.points.map((point) => <li key={point}>{point}</li>)}</ul> : null}
+            {item.image?.link ? (
+              <a href={item.image.link} target="_blank" rel="noreferrer">View credential</a>
+            ) : null}
+          </article>
+        </Reveal>
       ))}
     </div>
     <div>
-      <SectionHeader tag="Experience" title="Work History" />
+      <Reveal>
+        <SectionHeader tag="Experience" title="Work History" />
+      </Reveal>
       {experienceData.map((item, index) => (
-        <article className="timeline-card" key={index}>
-          <h3>
-            <TitleImage filename={item.image?.filename} link={item.image?.link} alt={item.title} />
-            {item.title}
-          </h3>
-          {item.subTitle && item.subTitle.map((subTitleItem) => <p key={subTitleItem}>{subTitleItem}</p>)}
-          <p>{item.body}</p>
-          <p>{item.images?.map((image) => (
-            <img key={image.filename} className="image-item" src={image.filename} alt={image.title} />
-          ))}</p>
-          <ul>{item.points?.map((point) => <li key={point}>{point}</li>)}</ul>
-        </article>
+        <Reveal key={index} delay={index * 0.08}>
+          <article className="timeline-card">
+            <h3>
+              <TitleImage filename={item.image?.filename} link={item.image?.link} alt={item.title} />
+              {item.title}
+            </h3>
+            {item.subTitle && item.subTitle.map((subTitleItem) => <p key={subTitleItem}>{subTitleItem}</p>)}
+            <p>{item.body}</p>
+            <p>{item.images?.map((image) => (
+              <img key={image.filename} className="image-item" src={image.filename} alt={image.title} />
+            ))}</p>
+            <ul>{item.points?.map((point) => <li key={point}>{point}</li>)}</ul>
+          </article>
+        </Reveal>
       ))}
     </div>
   </section>

--- a/src/sections/Interests.tsx
+++ b/src/sections/Interests.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from 'react';
+import Reveal from '../components/Reveal';
 import SectionHeader from '../components/SectionHeader';
 import ImageBlock from '../components/ImageBlock';
 import interestsData from '../data/interests.json';
@@ -10,17 +11,19 @@ interface InterestsProps {
 
 const Interests = ({ screenWidth }: InterestsProps) => (
   <section id="interests" className="section panel">
-    <SectionHeader tag="Interests" title="Personal Passions" />
-    <div className="split-grid">
-      <div className="about-copy">
-        {interestsData.map((item, index) => (
-          <Fragment key={index}>
-            <ul>{item.points.map((point) => <li key={point}>{point}</li>)}</ul>
-          </Fragment>
-        ))}
-      </div>
-    </div>
-    <ImageBlock data={interestsImagesData} screenWidth={screenWidth} />
+    <Reveal>
+      <SectionHeader tag="Interests" title="Personal Passions" />
+    </Reveal>
+    <Reveal className="about-copy" delay={0.1}>
+      {interestsData.map((item, index) => (
+        <Fragment key={index}>
+          <ul>{item.points.map((point) => <li key={point}>{point}</li>)}</ul>
+        </Fragment>
+      ))}
+    </Reveal>
+    <Reveal delay={0.15}>
+      <ImageBlock data={interestsImagesData} screenWidth={screenWidth} />
+    </Reveal>
   </section>
 );
 

--- a/src/sections/Projects.tsx
+++ b/src/sections/Projects.tsx
@@ -1,4 +1,5 @@
 import Slider, { Settings } from 'react-slick';
+import Reveal from '../components/Reveal';
 import SectionHeader from '../components/SectionHeader';
 import ProjectActions from '../components/ProjectActions';
 import projectsData from '../data/projects.json';
@@ -19,8 +20,10 @@ const Projects = ({ screenWidth }: ProjectsProps) => {
 
   return (
     <section id="projects" className="section panel">
-      <SectionHeader tag="Projects" title="Recent Work" />
-      <div className="carousel-container">
+      <Reveal>
+        <SectionHeader tag="Projects" title="Recent Work" />
+      </Reveal>
+      <Reveal className="carousel-container" delay={0.1}>
         <Slider {...sliderSettings}>
           {projectsData.map((project, index) => (
             <div key={index} className="project-slide">
@@ -46,7 +49,7 @@ const Projects = ({ screenWidth }: ProjectsProps) => {
             </div>
           ))}
         </Slider>
-      </div>
+      </Reveal>
     </section>
   );
 };

--- a/src/sections/Voluntary.tsx
+++ b/src/sections/Voluntary.tsx
@@ -1,20 +1,25 @@
+import Reveal from '../components/Reveal';
 import SectionHeader from '../components/SectionHeader';
 import TitleImage from '../components/TitleImage';
 import voluntaryData from '../data/voluntary.json';
 
 const Voluntary = () => (
   <section id="voluntary" className="section panel">
-    <SectionHeader tag="Voluntary Work" title="Giving Back" />
+    <Reveal>
+      <SectionHeader tag="Voluntary Work" title="Giving Back" />
+    </Reveal>
     <div className="grid cards-grid">
       {voluntaryData.map((item, index) => (
-        <article className="card" key={index}>
-          <h3>
-            <TitleImage filename={item.image?.filename} link={item.image?.link} alt={item.title} />
-            {item.title}
-          </h3>
-          {item.subTitle && item.subTitle.map((subTitleItem) => <p key={subTitleItem}>{subTitleItem}</p>)}
-          <p>{item.body}</p>
-        </article>
+        <Reveal key={index} delay={index * 0.08}>
+          <article className="card">
+            <h3>
+              <TitleImage filename={item.image?.filename} link={item.image?.link} alt={item.title} />
+              {item.title}
+            </h3>
+            {item.subTitle && item.subTitle.map((subTitleItem) => <p key={subTitleItem}>{subTitleItem}</p>)}
+            <p>{item.body}</p>
+          </article>
+        </Reveal>
       ))}
     </div>
   </section>

--- a/src/styles.css
+++ b/src/styles.css
@@ -368,6 +368,16 @@ a {
   gap: 24px;
 }
 
+.about-grid {
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  align-items: start;
+}
+
+.split-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+}
+
 .about-copy,
 .about-details {
   display: grid;
@@ -390,6 +400,11 @@ a {
   border-radius: 20px;
 }
 
+.info-card.accent {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+
 .info-card h3 {
   margin: 0 0 10px;
 }
@@ -398,6 +413,32 @@ a {
 .info-card ul {
   margin: 0;
   color: var(--text-muted);
+}
+
+.skill-shelves {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+  margin-top: 32px;
+}
+
+.skill-shelves h3 {
+  margin: 0 0 16px;
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.skill-shelves .pill-grid {
+  margin: 0;
+}
+
+.skill-shelves .pill-grid span {
+  display: inline-flex;
+  align-items: center;
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  color: var(--text);
 }
 
 .cards-grid,
@@ -631,12 +672,35 @@ a {
 }
 
 .timeline-card {
-  padding: 24px;
+  padding: 24px 24px 24px 28px;
+  border-left: 3px solid var(--accent);
+}
+
+.timeline-card h3 {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  font-weight: 600;
 }
 
 .timeline-card p,
 .timeline-card li {
   color: var(--text-muted);
+}
+
+.timeline-card a {
+  display: inline-block;
+  margin-top: 14px;
+  color: var(--accent-text);
+  font-weight: 500;
+}
+
+.timeline-card a:hover {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .timeline-card ul {
@@ -787,7 +851,8 @@ a {
   } */
 
   .about-grid,
-  .split-grid {
+  .split-grid,
+  .skill-shelves {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
Closes #27 (Slice 6 of the Visual Redesign PRD #21).

## What changed

Restyles the remaining content sections — Projects, Education, Voluntary, Codewars, Interests — to the modern-minimal direction, bringing them in line with the already-restyled Hero/NavBar/Footer (#26) and the About/Skills sections.

### Motion
- Wrapped section headers, cards and grids in `Reveal` across all five remaining sections, with staggered `delay` matching the existing About/Skills pattern. Sliders (Projects carousel, Interests `ImageBlock`) are revealed as whole blocks rather than per-slide to avoid fighting react-slick's clones.

### Styling gaps filled (token-driven, both themes)
- `.skill-shelves` — two-column Languages/Frameworks layout with surface pills; the markup referenced this class but it had no CSS.
- `.info-card.accent` — accent treatment for the About "Connect with me" card (referenced, previously unstyled).
- `.timeline-card` — accent left border, display-font heading, and styled "View credential" link for a coherent timeline look.
- `.about-grid` / `.split-grid` — added the **missing** desktop two-column rule. The 760px breakpoint already collapsed these to one column, so without a base rule they never actually split. Interests' single-child copy was moved off `split-grid` so it stays full-width.

All collapse to a single column at the existing 760px breakpoint.

## Out of scope / unchanged
- All content sourced unchanged from `src/data/*.json`.

## Verification
- `npm run build` ✅
- `npm test` ✅ (10/10)
- No headless browser available in this environment, so no screenshots; visual cross-theme/responsive sign-off is covered by Slice 7 (#28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)